### PR TITLE
chore: add prefix separator for path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /.python
 
 # compiled output
-dist
+/dist
 /tmp
 /out-tsc
 /schema.gql


### PR DESCRIPTION
Add prefix to a path in `.gitignore`.

This PR also encapsulates the initial run of the versioning and promotion GitHub Actions.