### PR TITLE
chore: only run the PR action on close

### DIFF
--- a/.github/workflows/sre-pr-auto-entrypoint.yml
+++ b/.github/workflows/sre-pr-auto-entrypoint.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     branches:
       - main # Only for the main branch
-    types: [opened, reopened, synchronize, closed]
+    types: [closed]
 
 jobs:
     # Let's get the branch name (Branches are different for PRs and pushes)


### PR DESCRIPTION
This PR sets the action to only run if the PR is closed, and the `pull_request.merged` == true